### PR TITLE
LIBTD-2293: Fix mogrify image cropping error

### DIFF
--- a/create_iiif_s3.rb
+++ b/create_iiif_s3.rb
@@ -2,6 +2,8 @@ require 'iiif_s3'
 require 'open-uri'
 require_relative 'lib/iiif_s3/manifest_override'
 IiifS3::Manifest.prepend IiifS3::ManifestOverride
+require_relative 'lib/iiif_s3/image_tile_override'
+IiifS3::ImageTile.prepend IiifS3::ImageTileOverride
 
 # Create directories on local disk for manifests/tiles to upload them to S3
 def create_directories(path)
@@ -45,8 +47,7 @@ def add_image(file, id)
     "is_master" => page_num == 1,
     "page_number" => page_num,
     "is_document" => false,
-    "description" => description,
-    "attribution" => "Special Collections, University Libraries, Virginia Tech",
+    "description" => description
   }  
 
   obj["section"] = "p#{page_num}"

--- a/lib/iiif_s3/image_tile_override.rb
+++ b/lib/iiif_s3/image_tile_override.rb
@@ -1,0 +1,15 @@
+module IiifS3
+  
+  module ImageTileOverride
+
+    protected
+
+    def resize(width=nil,height=nil)
+      @image.combine_options do |img|
+        img.crop "#{@tile[:width]}x#{@tile[:height]}+#{@tile[:x]}+#{@tile[:y]}"
+        img.resize "#{@tile[:xSize]}x#{@tile[:ySize]}"
+        img.repage.+
+      end
+    end
+  end
+end


### PR DESCRIPTION

**JIRA Ticket**: (https://webapps.es.vt.edu/jira/browse/LIBTD-2293) (:star:)

* Other Relevant Links (Meeting note, project page, related pull requests, etc.)

# What does this Pull Request do? (:star:)
This PR fixes the error: "mogrify-im6.q16: TIFF: negative image positions unsupported" when cropping TIFF images for tiling.

# What's the changes? (:star:)

* Adds "repage" option for mogrify in mini_magick
* Removes hardcoded "Special Collections" attribution in metadata

# How should this be tested?

* Try to re-tile images in vtlib-store SWVA/LJC_SL/EU/BEL and see if the tilings are displayed well in Mirador

# Additional Notes:

* Branch to be tested is: LIBTD-2293

# Interested parties
Tag (@soumikgh) interested parties

(:star:) Required fields
